### PR TITLE
Add an "import from clipboard" functionality

### DIFF
--- a/sholi/build.gradle
+++ b/sholi/build.gradle
@@ -3,10 +3,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0+'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 repositories {
     mavenCentral()
@@ -17,8 +17,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '19.1.0'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.3'
 
     sourceSets {
         main {
@@ -27,7 +27,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 19
+        targetSdkVersion 23
     }
     buildTypes {
         release {

--- a/sholi/src/main/java/name/soulayrol/rhaa/sholi/CheckingFragment.java
+++ b/sholi/src/main/java/name/soulayrol/rhaa/sholi/CheckingFragment.java
@@ -58,6 +58,8 @@ public class CheckingFragment extends AbstractListFragment implements
 
     private static final String TAG_IMPORT_DIALOG = "import_dialog";
 
+    private ClipboardManager _clipboard;
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
@@ -98,6 +100,12 @@ public class CheckingFragment extends AbstractListFragment implements
     }
 
     @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        _clipboard = (ClipboardManager)  context.getSystemService(Context.CLIPBOARD_SERVICE);
+    }
+
+    @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.checking, menu);
     }
@@ -132,13 +140,13 @@ public class CheckingFragment extends AbstractListFragment implements
                 transaction.commit();
                 return true;
             case R.id.action_paste:
-                ClipboardManager clipboard = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
-                CharSequence pasteData = clipboard.getPrimaryClip().getItemAt(0).getText();
-                if (pasteData != null) {
-                    Log.i("Clipboard: ",pasteData.toString());
-                    transaction = getFragmentManager().beginTransaction();
-                    if (getFragmentManager().findFragmentByTag(TAG_IMPORT_DIALOG) == null) {
-                        ImportFragment.newInstance(pasteData.toString()).show(transaction, TAG_IMPORT_DIALOG);
+                if (_clipboard != null) {
+                    CharSequence pasteData = _clipboard.getPrimaryClip().getItemAt(0).getText();
+                    if (pasteData != null) {
+                        transaction = getFragmentManager().beginTransaction();
+                        if (getFragmentManager().findFragmentByTag(TAG_IMPORT_DIALOG) == null) {
+                            ImportFragment.newInstance(pasteData.toString()).show(transaction, TAG_IMPORT_DIALOG);
+                        }
                     }
                 }
                 return true;

--- a/sholi/src/main/java/name/soulayrol/rhaa/sholi/CheckingFragment.java
+++ b/sholi/src/main/java/name/soulayrol/rhaa/sholi/CheckingFragment.java
@@ -18,10 +18,13 @@
 package name.soulayrol.rhaa.sholi;
 
 import android.app.FragmentTransaction;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -52,6 +55,8 @@ public class CheckingFragment extends AbstractListFragment implements
     private InterceptorFrameLayout _interceptor;
 
     private Map<Integer, String> _defaultActionClassNames;
+
+    private static final String TAG_IMPORT_DIALOG = "import_dialog";
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -118,12 +123,24 @@ public class CheckingFragment extends AbstractListFragment implements
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        FragmentTransaction transaction;
         switch (item.getItemId()) {
             case R.id.action_edit:
-                FragmentTransaction transaction = getFragmentManager().beginTransaction();
+                transaction = getFragmentManager().beginTransaction();
                 transaction.replace(R.id.container, new EditFragment());
                 transaction.addToBackStack(null);
                 transaction.commit();
+                return true;
+            case R.id.action_paste:
+                ClipboardManager clipboard = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+                CharSequence pasteData = clipboard.getPrimaryClip().getItemAt(0).getText();
+                if (pasteData != null) {
+                    Log.i("Clipboard: ",pasteData.toString());
+                    transaction = getFragmentManager().beginTransaction();
+                    if (getFragmentManager().findFragmentByTag(TAG_IMPORT_DIALOG) == null) {
+                        ImportFragment.newInstance(pasteData.toString()).show(transaction, TAG_IMPORT_DIALOG);
+                    }
+                }
                 return true;
             case R.id.action_menu:
                 getActivity().openContextMenu(_listView);

--- a/sholi/src/main/java/name/soulayrol/rhaa/sholi/CheckingFragment.java
+++ b/sholi/src/main/java/name/soulayrol/rhaa/sholi/CheckingFragment.java
@@ -18,13 +18,10 @@
 package name.soulayrol.rhaa.sholi;
 
 import android.app.FragmentTransaction;
-import android.content.ClipData;
-import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -56,9 +53,7 @@ public class CheckingFragment extends AbstractListFragment implements
 
     private Map<Integer, String> _defaultActionClassNames;
 
-    private static final String TAG_IMPORT_DIALOG = "import_dialog";
 
-    private ClipboardManager _clipboard;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -100,12 +95,6 @@ public class CheckingFragment extends AbstractListFragment implements
     }
 
     @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        _clipboard = (ClipboardManager)  context.getSystemService(Context.CLIPBOARD_SERVICE);
-    }
-
-    @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.checking, menu);
     }
@@ -138,17 +127,6 @@ public class CheckingFragment extends AbstractListFragment implements
                 transaction.replace(R.id.container, new EditFragment());
                 transaction.addToBackStack(null);
                 transaction.commit();
-                return true;
-            case R.id.action_paste:
-                if (_clipboard != null) {
-                    CharSequence pasteData = _clipboard.getPrimaryClip().getItemAt(0).getText();
-                    if (pasteData != null) {
-                        transaction = getFragmentManager().beginTransaction();
-                        if (getFragmentManager().findFragmentByTag(TAG_IMPORT_DIALOG) == null) {
-                            ImportFragment.newInstance(pasteData.toString()).show(transaction, TAG_IMPORT_DIALOG);
-                        }
-                    }
-                }
                 return true;
             case R.id.action_menu:
                 getActivity().openContextMenu(_listView);

--- a/sholi/src/main/java/name/soulayrol/rhaa/sholi/EditFragment.java
+++ b/sholi/src/main/java/name/soulayrol/rhaa/sholi/EditFragment.java
@@ -240,7 +240,10 @@ public class EditFragment extends AbstractListFragment {
                 ClipData clip = _clipboard.getPrimaryClip();
                 if (clip == null)
                     return true;
-                CharSequence pasteData = clip.getItemAt(0).coerceToText(_context);
+                ClipData.Item citem = clip.getItemAt(0);
+                if (citem == null)
+                    return true;
+                CharSequence pasteData = citem.coerceToText(_context);
                 if (pasteData == null)
                     return true;
                 FragmentTransaction transaction = getFragmentManager().beginTransaction();

--- a/sholi/src/main/res/layout/fragment_edit.xml
+++ b/sholi/src/main/res/layout/fragment_edit.xml
@@ -26,8 +26,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:hint="@string/fragment_edit_input_hint"
-        android:inputType="textShortMessage|textCapSentences"
-        android:editable="true" />
+        android:inputType="textShortMessage|textCapSentences" />
 
     <FrameLayout
         android:id="@+id/z_list_frame"

--- a/sholi/src/main/res/menu/checking.xml
+++ b/sholi/src/main/res/menu/checking.xml
@@ -26,12 +26,6 @@
         android:orderInCategory="1"
         android:showAsAction="ifRoom" />
 
-    <item android:id="@+id/action_paste"
-        android:icon="@android:drawable/ic_menu_agenda"
-        android:title="@string/action_checking_paste"
-        android:orderInCategory="1"
-        android:showAsAction="ifRoom" />
-
     <item android:id="@+id/action_menu"
         android:icon="@android:drawable/ic_menu_manage"
         android:title="@string/action_checking_menu"

--- a/sholi/src/main/res/menu/checking.xml
+++ b/sholi/src/main/res/menu/checking.xml
@@ -26,6 +26,12 @@
         android:orderInCategory="1"
         android:showAsAction="ifRoom" />
 
+    <item android:id="@+id/action_paste"
+        android:icon="@android:drawable/ic_menu_agenda"
+        android:title="@string/action_checking_paste"
+        android:orderInCategory="1"
+        android:showAsAction="ifRoom" />
+
     <item android:id="@+id/action_menu"
         android:icon="@android:drawable/ic_menu_manage"
         android:title="@string/action_checking_menu"

--- a/sholi/src/main/res/menu/edit.xml
+++ b/sholi/src/main/res/menu/edit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".MainActivity">
+
+    <item
+        android:id="@+id/action_paste"
+        android:icon="@android:drawable/ic_menu_agenda"
+        android:orderInCategory="1"
+        android:showAsAction="ifRoom"
+        android:title="@string/action_edit_paste" />
+
+</menu>

--- a/sholi/src/main/res/values/strings.xml
+++ b/sholi/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  ShoLi, a simple tool to produce short (shopping) lists.
 
  Copyright (C) 2013,2014,2015  David Soulayrol
@@ -17,9 +16,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 
     <string name="app_name">ShoLi</string>
 
@@ -97,6 +94,7 @@
     <string name="fragment_data_erase_button">Erase All</string>
 
     <string name="fragment_settings_marker_error">Marker is invalid</string>
+    <string name="action_checking_paste">Paste from clipboard</string>
 
     <!-- Zero is not working as expected in plurals.
          See http://code.google.com/p/android/issues/detail?id=8287 -->

--- a/sholi/src/main/res/values/strings.xml
+++ b/sholi/src/main/res/values/strings.xml
@@ -94,7 +94,7 @@
     <string name="fragment_data_erase_button">Erase All</string>
 
     <string name="fragment_settings_marker_error">Marker is invalid</string>
-    <string name="action_checking_paste">Paste from clipboard</string>
+    <string name="action_edit_paste">Paste from clipboard</string>
 
     <!-- Zero is not working as expected in plurals.
          See http://code.google.com/p/android/issues/detail?id=8287 -->


### PR DESCRIPTION
This patch adds a menu item, which imports sholi items from the clipboard. That is especially useful for sharing shopping lists through messenger apps like Telegram.. .
